### PR TITLE
Make speedchoice labels consistent with pret's disassembly

### DIFF
--- a/maps/BlackthornGym1F.asm
+++ b/maps/BlackthornGym1F.asm
@@ -56,7 +56,7 @@ BlackthornGymClairScript:
 	waitsfx
 	setflag ENGINE_RISINGBADGE
 	checkcode VAR_BADGES
-	scall BlackthornGymTriggerRockets
+	scall BlackthornGymActivateRockets
 	specialphonecall SPECIALCALL_MASTERBALL
 	writetext BlackthornGymClairText_DescribeBadge
 	jump .GiveTM
@@ -97,7 +97,7 @@ BlackthornGymClairScript:
 	closetext
 	end
 
-BlackthornGymTriggerRockets:
+BlackthornGymActivateRockets:
 	if_equal 7, .RadioTowerRockets
 	if_equal 6, .GoldenrodRockets
 	end

--- a/maps/CeladonGym.asm
+++ b/maps/CeladonGym.asm
@@ -34,7 +34,7 @@ CeladonGymErikaScript:
 	waitsfx
 	setflag ENGINE_RAINBOWBADGE
 	checkcode VAR_BADGES
-	scall CeladonGymTriggerRockets
+	scall CeladonGymActivateRockets
 .FightDone:
 	checkevent EVENT_GOT_TM19_GIGA_DRAIN
 	iftrue .GotGigaDrain
@@ -49,7 +49,7 @@ CeladonGymErikaScript:
 	closetext
 	end
 
-CeladonGymTriggerRockets:
+CeladonGymActivateRockets:
 	if_equal 7, .RadioTowerRockets
 	if_equal 6, .GoldenrodRockets
 	end

--- a/maps/CeruleanGym.asm
+++ b/maps/CeruleanGym.asm
@@ -78,14 +78,14 @@ CeruleanGymMistyScript:
 	waitsfx
 	setflag ENGINE_CASCADEBADGE
 	checkcode VAR_BADGES
-	scall CeruleanGymTriggerRockets
+	scall CeruleanGymActivateRockets
 .FightDone:
 	writetext MistyFightDoneText
 	waitbutton
 	closetext
 	end
 
-CeruleanGymTriggerRockets:
+CeruleanGymActivateRockets:
 	if_equal 7, .RadioTowerRockets
 	if_equal 6, .GoldenrodRockets
 	end

--- a/maps/FuchsiaGym.asm
+++ b/maps/FuchsiaGym.asm
@@ -40,7 +40,7 @@ FuchsiaGymJanineScript:
 	waitsfx
 	setflag ENGINE_SOULBADGE
 	checkcode VAR_BADGES
-	scall FuchsiaGymTriggerRockets
+	scall FuchsiaGymActivateRockets
 	sjump .AfterBattle
 .FightDone:
 	faceplayer
@@ -59,7 +59,7 @@ FuchsiaGymJanineScript:
 	closetext
 	end
 
-FuchsiaGymTriggerRockets:
+FuchsiaGymActivateRockets:
 	if_equal 7, .RadioTowerRockets
 	if_equal 6, .GoldenrodRockets
 	end

--- a/maps/PewterGym.asm
+++ b/maps/PewterGym.asm
@@ -28,7 +28,7 @@ PewterGymBrockScript:
 	waitsfx
 	setflag ENGINE_BOULDERBADGE
 	checkcode VAR_BADGES
-	scall PewterGymTriggerRockets
+	scall PewterGymActivateRockets
 	writetext BrockBoulderBadgeText
 	waitbutton
 	closetext
@@ -40,7 +40,7 @@ PewterGymBrockScript:
 	closetext
 	end
 
-PewterGymTriggerRockets:
+PewterGymActivateRockets:
 	if_equal 7, .RadioTowerRockets
 	if_equal 6, .GoldenrodRockets
 	end

--- a/maps/SaffronGym.asm
+++ b/maps/SaffronGym.asm
@@ -34,7 +34,7 @@ SaffronGymSabrinaScript:
 	waitsfx
 	setflag ENGINE_MARSHBADGE
 	checkcode VAR_BADGES
-	scall SaffronGymTriggerRockets
+	scall SaffronGymActivateRockets
 	writetext SabrinaMarshBadgeText
 	waitbutton
 	closetext
@@ -46,7 +46,7 @@ SaffronGymSabrinaScript:
 	closetext
 	end
 
-SaffronGymTriggerRockets:
+SaffronGymActivateRockets:
 	if_equal 7, .RadioTowerRockets
 	if_equal 6, .GoldenrodRockets
 	end

--- a/maps/SeafoamGym.asm
+++ b/maps/SeafoamGym.asm
@@ -33,7 +33,7 @@ SeafoamGymBlaineScript:
 	waitsfx
 	setflag ENGINE_VOLCANOBADGE
 	checkcode VAR_BADGES
-	scall SeafoamGymTriggerRockets
+	scall SeafoamGymActivateRockets
 	writetext BlaineAfterBattleText
 	waitbutton
 	closetext
@@ -45,7 +45,7 @@ SeafoamGymBlaineScript:
 	closetext
 	end
 
-SeafoamGymTriggerRockets:
+SeafoamGymActivateRockets:
 	if_equal 7, .RadioTowerRockets
 	if_equal 6, .GoldenrodRockets
 	end

--- a/maps/VermilionGym.asm
+++ b/maps/VermilionGym.asm
@@ -32,7 +32,7 @@ VermilionGymSurgeScript:
 	waitsfx
 	setflag ENGINE_THUNDERBADGE
 	checkcode VAR_BADGES
-	scall VermilionGymTriggerRockets
+	scall VermilionGymActivateRockets
 	writetext LtSurgeThunderBadgeText
 	waitbutton
 	closetext
@@ -44,7 +44,7 @@ VermilionGymSurgeScript:
 	closetext
 	end
 	
-VermilionGymTriggerRockets:
+VermilionGymActivateRockets:
 	if_equal 7, .RadioTowerRockets
 	if_equal 6, .GoldenrodRockets
 	end

--- a/maps/ViridianGym.asm
+++ b/maps/ViridianGym.asm
@@ -26,7 +26,7 @@ ViridianGymBlueScript:
 	waitsfx
 	setflag ENGINE_EARTHBADGE
 	checkcode VAR_BADGES
-	scall ViridianGymTriggerRockets
+	scall ViridianGymActivateRockets
 	writetext LeaderBlueAfterText
 	waitbutton
 	closetext
@@ -38,7 +38,7 @@ ViridianGymBlueScript:
 	closetext
 	end
 
-ViridianGymTriggerRockets:
+ViridianGymActivateRockets:
 	if_equal 7, .RadioTowerRockets
 	if_equal 6, .GoldenrodRockets
 	end


### PR DESCRIPTION
pret changed ActivateRockets to TriggerRockets, so we should do the same.

for context, these labels and code were added to support CKIR's badge randomization. i don't expect that changing these labels will affect anyone other than myself and ERC, the full item randomizer developer, and i can talk to ERC about that if these changes are merged.