### PR TITLE
Prevent Clair from giving TM early when Easy Clair turned off - Fixes#23

### DIFF
--- a/constants/event_flags.asm
+++ b/constants/event_flags.asm
@@ -201,8 +201,9 @@
 	const EVENT_GAVE_GS_BALL_TO_KURT
 	const EVENT_FOREST_IS_RESTLESS
 	const EVENT_ANSWERED_DRAGON_MASTER_QUIZ_WRONG
+; Speedchoice workaround events
+	const EVENT_DRAGON_SHRINE_PASSED_TEST
 ; Unused
-	const EVENT_0C2
 	const EVENT_0C3
 	const EVENT_0C4
 	const EVENT_0C5

--- a/maps/BlackthornGym1F.asm
+++ b/maps/BlackthornGym1F.asm
@@ -64,8 +64,14 @@ BlackthornGymClairScript:
 	end
 
 .FightDone:
+	checkpermaoptions EASY_CLAIR_BADGE
+	iftrue .EasyClair
+	checkevent EVENT_DRAGON_SHRINE_PASSED_TEST
+	iffalse .TooMuchToExpect
+.EasyClair
 	checkevent EVENT_GOT_TM24_DRAGONBREATH
 	iffalse .AlreadyGotBadge
+.TooMuchToExpect
 	writetext ClairText_TooMuchToExpect
 	waitbutton
 	closetext

--- a/maps/DragonShrine.asm
+++ b/maps/DragonShrine.asm
@@ -114,6 +114,7 @@ DragonShrine_MapScripts:
 	checkevent EVENT_TEMPORARY_UNTIL_MAP_RELOAD_2
 	iftrue .Question1
 .PassedTheTest:
+	setevent EVENT_DRAGON_SHRINE_PASSED_TEST
 	writetext DragonShrinePassedTestText
 	waitbutton
 	setscene SCENE_FINISHED


### PR DESCRIPTION
With Easy Clair off, Clair would give her TM if you talk to her after beating her, instead of forcing you to go to Dragon's Den and do the Shrine quiz to get it.