### PR TITLE
Set Rival name before game starts

### DIFF
--- a/engine/menus/intro_permaoptions.asm
+++ b/engine/menus/intro_permaoptions.asm
@@ -20,6 +20,7 @@ endr
 	ld a, "@"
 	ld [wPlayerName], a
 	ld hl, wPlayerGender
+	ld [wRivalName], a
 	set 0, [hl]
 .setOptions
 	callba PermaOptionsMenu

--- a/engine/menus/options/perma_options.asm
+++ b/engine/menus/options/perma_options.asm
@@ -1,27 +1,21 @@
 PermaOptionsP1String::
 	db "PRESET (A: SET)<LF>"
 	db "        :<LF>"
-	db "NAME<LF>"
+	db "PLAYER NAME<LF>"
 	db "        :<LF>"
 	db "GENDER<LF>"
 	db "        :<LF>"
-	db "ROCKET SECTIONS<LF>"
+	db "RIVAL NAME<LF>"
 	db "        :<LF>"
-	db "SPINNERS<LF>"
-	db "        :<LF>"
-	db "TRAINER VISION<LF>"
-	db "        :<LF>"
-	db "NERF HMs<LF>"
+	db "RACE GOAL<LF>"
 	db "        :@"
 
 PermaOptionsP1Pointers::
 	dw Options_Preset
-	dw Options_Name
+	dw Options_PlayerName
 	dw Options_PlayerGender
-	dw Options_Rocketless
-	dw Options_Spinners
-	dw Options_TrainerVision
-	dw Options_NerfHMs
+	dw Options_RivalName
+	dw Options_RaceGoal
 	dw Options_PermaOptionsPage
 PermaOptionsP1PointersEnd::
 
@@ -115,7 +109,7 @@ rept (NUM_PERMAOPTIONS_BYTES + 2)
 endr
 	ret
 
-Options_Name:
+Options_PlayerName:
 	and A_BUTTON
 	jr z, .GetText
 	ld a, [wJumptableIndex]
@@ -137,7 +131,6 @@ Options_Name:
 	call PlaceString
 	and a
 	ret
-
 .NotSetString
 	db "NOT SET@"
 
@@ -155,101 +148,46 @@ Options_PlayerGender:
 .Female
 	db "FEMALE@"
 
-Options_Rocketless:
-	ld hl, ROCKETLESS_ADDRESS
-	lb bc, ROCKETLESS, 9
-	ld de, .NormalPurge
-	jp Options_TrueFalse_IRLocked
-.NormalPurge
-	dw .Normal
-	dw .Purge
+Options_RivalName:
+	and A_BUTTON
+	jr z, .GetText
+	ld a, [wJumptableIndex]
+	push af
+	ld b, 2
+	ld de, wRivalName
+	callba NamingScreen
+	call DrawOptionsMenu
+	pop af
+	ld [wJumptableIndex], a
+.GetText
+	ld de, wRivalName
+	ld a, [de]
+	cp "@"
+	jr nz, .Display
+	ld de, .NotSetString
+.Display
+	hlcoord 11, 9
+	call PlaceString
+	and a
+	ret
+.NotSetString
+	db "NOT SET@"
 
-.Normal
-	db "NORMAL@"
-.Purge
-	db "PURGE @"
-
-Options_Spinners:
+Options_RaceGoal:
 	ld hl, .Data
 	jp Options_Multichoice
 
 .Data:
-	multichoiceoptiondata SPINNERS_ADDRESS, SPINNERS, SPINNERS_SIZE, 11, NUM_OPTIONS, .Strings
-
-.Strings
-	dw .Normal
-	dw .Purge
-	dw .Hell
-	dw .Why
+	multichoiceoptiondata RACEGOAL_ADDRESS, RACEGOAL, RACEGOAL_SIZE, 11, NUM_OPTIONS, .Strings
+.Strings:
+	dw .Manual
+	dw .E4
+	dw .Red
 .Strings_End:
 
-.Normal
-	db "NORMAL@"
-.Purge
-	db "PURGE @"
-.Hell
-	db "HELL  @"
-.Why
-	db "WHY   @"
-
-Options_TrainerVision:
-	ld hl, MAX_RANGE_ADDRESS
-	lb bc, MAX_RANGE, 13
-	ld de, .NormalMax
-	jp Options_TrueFalse
-.NormalMax
-	dw .Normal
-	dw .Max
-
-.Normal
-	db "NORMAL@"
-.Max
-	db "MAX   @"
-
-Options_NerfHMs:
-	ld hl, NERF_HMS_ADDRESS
-	ld a, [wRandomizedMovesStatus]
-	dec a
-	jr z, .normalCase
-	dec a
-	jr z, .randomizedMoves
-; check whether move data is randomized
-	ld hl, MovesHMNerfs
-	ld a, BANK(MovesHMNerfs)
-	ld bc, MOVE_LENGTH
-	ld de, wStringBuffer5
-	call FarCopyBytes
-	ld hl, .PoundUnchanged
-	ld de, wStringBuffer5
-	ld c, MOVE_LENGTH
-	call CompareBytes
-	ld a, 1
-	jr z, .write
-	inc a
-.write
-	ld [wRandomizedMovesStatus], a
-	jr Options_NerfHMs
-.normalCase
-	ldh a, [hJoyPressed]
-	lb bc, NERF_HMS, 15
-	ld de, .NoYes
-	jp Options_TrueFalse
-.randomizedMoves
-	set NERF_HMS, [hl]
-	ld de, .Randomized
-	hlcoord 2, 15
-	call PlaceString
-	and a
-	ret
-.NoYes
-	dw .No
-	dw .Yes
-
-.No
-	db "NO @"
-.Yes
-	db "YES@"
-.Randomized
-	db "RANDOMIZED MOVES!@"
-.PoundUnchanged
-	move POUND,        EFFECT_NORMAL_HIT,         40, NORMAL,   100, 35,   0
+.Manual
+	db "MANUAL@"
+.E4
+	db "E4    @"
+.Red
+	db "RED   @"

--- a/engine/menus/options/perma_options_2.asm
+++ b/engine/menus/options/perma_options_2.asm
@@ -1,4 +1,10 @@
 PermaOptionsP2String::
+	db "ROCKET SECTIONS<LF>"
+	db "        :<LF>"
+	db "SPINNERS<LF>"
+	db "        :<LF>"
+	db "TRAINER VISION<LF>"
+	db "        :<LF>"
 	db "BETTER ENC. SLOTS<LF>"
 	db "        :<LF>"
 	db "EXPERIENCE<LF>"
@@ -6,28 +12,73 @@ PermaOptionsP2String::
 	db "EXP SPLITTING<LF>"
 	db "        :<LF>"
 	db "CATCH EXP<LF>"
-	db "        :<LF>"
-	db "BETTER MARTS<LF>"
-	db "        :<LF>"
-	db "GOOD EARLY WILDS<LF>"
-	db "        :<LF>"
-	db "RACE GOAL<LF>"
 	db "        :@"
 
 PermaOptionsP2Pointers::
+	dw Options_Rocketless
+	dw Options_Spinners
+	dw Options_TrainerVision
 	dw Options_BetterEncSlots
 	dw Options_EXP
 	dw Options_EXPSplitting
 	dw Options_CatchEXP
-	dw Options_BetterMarts
-	dw Options_GoodEarlyWilds
-	dw Options_RaceGoal
 	dw Options_PermaOptionsPage
 PermaOptionsP2PointersEnd::
 
+Options_Rocketless:
+	ld hl, ROCKETLESS_ADDRESS
+	lb bc, ROCKETLESS, 3
+	ld de, .NormalPurge
+	jp Options_TrueFalse_IRLocked
+.NormalPurge
+	dw .Normal
+	dw .Purge
+
+.Normal
+	db "NORMAL@"
+.Purge
+	db "PURGE @"
+
+Options_Spinners:
+	ld hl, .Data
+	jp Options_Multichoice
+
+.Data:
+	multichoiceoptiondata SPINNERS_ADDRESS, SPINNERS, SPINNERS_SIZE, 5, NUM_OPTIONS, .Strings
+
+.Strings
+	dw .Normal
+	dw .Purge
+	dw .Hell
+	dw .Why
+.Strings_End:
+
+.Normal
+	db "NORMAL@"
+.Purge
+	db "PURGE @"
+.Hell
+	db "HELL  @"
+.Why
+	db "WHY   @"
+
+Options_TrainerVision:
+	ld hl, MAX_RANGE_ADDRESS
+	lb bc, MAX_RANGE, 7
+	ld de, .NormalMax
+	jp Options_TrueFalse
+.NormalMax
+	dw .Normal
+	dw .Max
+
+.Normal
+	db "NORMAL@"
+.Max
+	db "MAX   @"
+
 Options_BetterEncSlots:
 	ld hl, BETTER_ENC_SLOTS_ADDRESS
-	lb bc, BETTER_ENC_SLOTS, 3
+	lb bc, BETTER_ENC_SLOTS, 9
 	jp Options_OnOff
 
 Options_EXP:
@@ -35,7 +86,7 @@ Options_EXP:
 	jp Options_Multichoice
 
 .Data:
-	multichoiceoptiondata EXP_FORMULA_ADDRESS, EXP_FORMULA, EXP_FORMULA_SIZE, 5, NUM_OPTIONS, .Strings
+	multichoiceoptiondata EXP_FORMULA_ADDRESS, EXP_FORMULA, EXP_FORMULA_SIZE, 11, NUM_OPTIONS, .Strings
 .Strings:
 	dw .Normal
 	dw .BW
@@ -54,7 +105,7 @@ Options_EXPSplitting:
 	jp Options_Multichoice
 
 .Data:
-	multichoiceoptiondata EXP_SPLITTING_ADDRESS, EXP_SPLITTING, EXP_SPLITTING_SIZE, 7, NUM_OPTIONS, .Strings
+	multichoiceoptiondata EXP_SPLITTING_ADDRESS, EXP_SPLITTING, EXP_SPLITTING_SIZE, 13, NUM_OPTIONS, .Strings
 .Strings:
 	dw .Normal
 	dw .Gen67
@@ -70,34 +121,5 @@ Options_EXPSplitting:
 
 Options_CatchEXP:
 	ld hl, CATCH_EXP_ADDRESS
-	lb bc, CATCH_EXP, 9
+	lb bc, CATCH_EXP, 15
 	jp Options_OnOff
-
-Options_BetterMarts:
-	ld hl, BETTER_MARTS_ADDRESS
-	lb bc, BETTER_MARTS, 11
-	jp Options_OnOff
-
-Options_GoodEarlyWilds:
-	ld hl, EVOLVED_EARLY_WILDS_ADDRESS
-	lb bc, EVOLVED_EARLY_WILDS, 13
-	jp Options_OnOff
-
-Options_RaceGoal:
-	ld hl, .Data
-	jp Options_Multichoice
-
-.Data:
-	multichoiceoptiondata RACEGOAL_ADDRESS, RACEGOAL, RACEGOAL_SIZE, 15, NUM_OPTIONS, .Strings
-.Strings:
-	dw .Manual
-	dw .E4
-	dw .Red
-.Strings_End:
-
-.Manual
-	db "MANUAL@"
-.E4
-	db "E4    @"
-.Red
-	db "RED   @"

--- a/engine/menus/options/perma_options_3.asm
+++ b/engine/menus/options/perma_options_3.asm
@@ -1,43 +1,34 @@
 PermaOptionsP3String::
-	db "KANTO ACCESS<LF>"
+	db "BETTER MARTS<LF>"
 	db "        :<LF>"
 	db "EASY TIN TOWER<LF>"
 	db "        :<LF>"
 	db "EASY CLAIR BADGE<LF>"
-	db "        :<LF>"
-	db "DEX AREA BEEP<LF>"
 	db "        :<LF>"
 	db "RODS ALWAYS WORK<LF>"
 	db "        :<LF>"
 	db "FAST EGG MAKING<LF>"
 	db "        :<LF>"
 	db "FAST EGG HATCHING<LF>"
+	db "        :<LF>"
+	db "START WITH BIKE<LF>"
 	db "        :@"
-
+	
 PermaOptionsP3Pointers::
-	dw Options_KantoAccess
+	dw Options_BetterMarts
 	dw Options_EasyTinTower
 	dw Options_EasyClairBadge
-	dw Options_DexAreaBeep
 	dw Options_RodsAlwaysWork
 	dw Options_FastEggMaking
 	dw Options_FastEggHatching
+	dw Options_StartWithBike
 	dw Options_PermaOptionsPage
 PermaOptionsP3PointersEnd::
 
-Options_KantoAccess:
-	ld hl, EARLY_KANTO_ADDRESS
-	lb bc, EARLY_KANTO, 3
-	ld de, .NormalEarly
-	jp Options_TrueFalse_IRLocked
-.NormalEarly
-	dw .Normal
-	dw .Early
-
-.Normal
-	db "NORMAL@"
-.Early
-	db "EARLY @"
+Options_BetterMarts:
+	ld hl, BETTER_MARTS_ADDRESS
+	lb bc, BETTER_MARTS, 3
+	jp Options_OnOff
 
 Options_EasyTinTower:
 	ld hl, EASY_TIN_TOWER_ADDRESS
@@ -49,22 +40,23 @@ Options_EasyClairBadge:
 	lb bc, EASY_CLAIR_BADGE, 7
 	jp Options_OnOff_IRLocked
 
-Options_DexAreaBeep:
-	ld hl, DEX_AREA_BEEP_ADDRESS
-	lb bc, DEX_AREA_BEEP, 9
-	jp Options_OnOff
-
 Options_RodsAlwaysWork:
 	ld hl, ROD_ALWAYS_SUCCEEDS_ADDRESS
-	lb bc, ROD_ALWAYS_SUCCEEDS, 11
+	lb bc, ROD_ALWAYS_SUCCEEDS, 9
 	jp Options_OnOff
+
 
 Options_FastEggMaking:
 	ld hl, FAST_EGG_GENERATION_ADDRESS
-	lb bc, FAST_EGG_GENERATION, 13
+	lb bc, FAST_EGG_GENERATION, 11
 	jp Options_OnOff
 
 Options_FastEggHatching:
 	ld hl, FAST_EGG_HATCHING_ADDRESS
-	lb bc, FAST_EGG_HATCHING, 15
+	lb bc, FAST_EGG_HATCHING, 13
+	jp Options_OnOff
+
+Options_StartWithBike:
+	ld hl, START_WITH_BIKE_ADDRESS
+	lb bc, START_WITH_BIKE, 15
 	jp Options_OnOff

--- a/engine/menus/options/perma_options_4.asm
+++ b/engine/menus/options/perma_options_4.asm
@@ -1,29 +1,105 @@
 PermaOptionsP4String::
+	db "KANTO ACCESS<LF>"
+	db "        :<LF>"
 	db "EARLY KANTO DEX<LF>"
 	db "        :<LF>"
-	db "START WITH BIKE<LF>"
+	db "DEX AREA BEEP<LF>"
+	db "        :<LF>"
+	db "GOOD EARLY WILDS<LF>"
+	db "        :<LF>"
+	db "NERF HMs<LF>"
 	db "        :<LF>"
 	db "METRONOME ONLY<LF>"
 	db "        :@"
 
 PermaOptionsP4Pointers::
+	dw Options_KantoAccess
 	dw Options_EarlyKantoDex
-	dw Options_StartWithBike
+	dw Options_DexAreaBeep
+	dw Options_GoodEarlyWilds
+	dw Options_NerfHMs
 	dw Options_MetronomeOnly
 	dw Options_PermaOptionsPage
 PermaOptionsP4PointersEnd::
 
+Options_KantoAccess:
+	ld hl, EARLY_KANTO_ADDRESS
+	lb bc, EARLY_KANTO, 3
+	ld de, .NormalEarly
+	jp Options_TrueFalse_IRLocked
+.NormalEarly
+	dw .Normal
+	dw .Early
+
+.Normal
+	db "NORMAL@"
+.Early
+	db "EARLY @"
+
 Options_EarlyKantoDex:
 	ld hl, EARLY_KANTO_DEX_ADDRESS
-	lb bc, EARLY_KANTO_DEX, 3
+	lb bc, EARLY_KANTO_DEX, 5
 	jp Options_OnOff
 
-Options_StartWithBike:
-	ld hl, START_WITH_BIKE_ADDRESS
-	lb bc, START_WITH_BIKE, 5
+Options_DexAreaBeep:
+	ld hl, DEX_AREA_BEEP_ADDRESS
+	lb bc, DEX_AREA_BEEP, 7
 	jp Options_OnOff
+
+Options_GoodEarlyWilds:
+	ld hl, EVOLVED_EARLY_WILDS_ADDRESS
+	lb bc, EVOLVED_EARLY_WILDS, 9
+	jp Options_OnOff
+
+Options_NerfHMs:
+	ld hl, NERF_HMS_ADDRESS
+	ld a, [wRandomizedMovesStatus]
+	dec a
+	jr z, .normalCase
+	dec a
+	jr z, .randomizedMoves
+; check whether move data is randomized
+	ld hl, MovesHMNerfs
+	ld a, BANK(MovesHMNerfs)
+	ld bc, MOVE_LENGTH
+	ld de, wStringBuffer5
+	call FarCopyBytes
+	ld hl, .PoundUnchanged
+	ld de, wStringBuffer5
+	ld c, MOVE_LENGTH
+	call CompareBytes
+	ld a, 1
+	jr z, .write
+	inc a
+.write
+	ld [wRandomizedMovesStatus], a
+	jr Options_NerfHMs
+.normalCase
+	ldh a, [hJoyPressed]
+	lb bc, NERF_HMS, 11
+	ld de, .NoYes
+	jp Options_TrueFalse
+.randomizedMoves
+	set NERF_HMS, [hl]
+	ld de, .Randomized
+	hlcoord 2, 15
+	call PlaceString
+	and a
+	ret
+.NoYes
+	dw .No
+	dw .Yes
+
+.No
+	db "NO @"
+.Yes
+	db "YES@"
+.Randomized
+	db "RANDOMIZED MOVES!@"
+.PoundUnchanged
+	move POUND,        EFFECT_NORMAL_HIT,         40, NORMAL,   100, 35,   0
 
 Options_MetronomeOnly:
 	ld hl, METRONOME_ONLY_ADDRESS
-	lb bc, METRONOME_ONLY, 7
+	lb bc, METRONOME_ONLY, 13
 	jp Options_OnOff

--- a/engine/menus/options_menu.asm
+++ b/engine/menus/options_menu.asm
@@ -55,7 +55,7 @@ OptionsMenuCommon::
 	jr c, .exit
 	ld a, [wPlayerName]
 	cp "@"
-	jr nz, .exit
+	jr nz, .checkRivalName
 	ld a, [HOLD_TO_MASH_ADDRESS]
 	push af
 	and $ff ^ HOLD_TO_MASH_VAL
@@ -65,6 +65,19 @@ OptionsMenuCommon::
 	pop af
 	ld [HOLD_TO_MASH_ADDRESS], a
 	jr .pageLoad
+.checkRivalName
+	ld a, [wRivalName]
+	cp "@"
+	jr nz, .exit
+	ld a, [HOLD_TO_MASH_ADDRESS]
+	push af
+	and $ff ^ HOLD_TO_MASH_VAL
+	ld [HOLD_TO_MASH_ADDRESS], a
+	ld hl, NameNotSetText
+	call PrintText
+	pop af
+	ld [HOLD_TO_MASH_ADDRESS], a
+	jr .pageLoad	
 .exit
 	pop af
 	ld [hInMenu], a
@@ -514,8 +527,8 @@ INCLUDE "engine/menus/options/perma_options_3.asm"
 INCLUDE "engine/menus/options/perma_options_4.asm"
 
 NameNotSetText::
-	text "Please set your"
-	line "name on page 1!@"
+	text "Please set both"
+	line "names on page 1!@"
 	start_asm
 	ld de, SFX_WRONG
 	call PlaySFX

--- a/maps/CherrygroveCity.asm
+++ b/maps/CherrygroveCity.asm
@@ -455,7 +455,7 @@ SilverCherrygroveWinText:
 CherrygroveRivalText_YouLost:
 	text "<……> <……> <……>"
 
-	para "My name's ???."
+	para "My name's <RIVAL>."
 
 	para "I'm going to be"
 	line "the world's great-"
@@ -471,7 +471,7 @@ SilverCherrygroveLossText:
 CherrygroveRivalText_YouWon:
 	text "<……> <……> <……>"
 
-	para "My name's ???."
+	para "My name's <RIVAL>."
 
 	para "I'm going to be"
 	line "the world's great-"

--- a/maps/ElmsLab.asm
+++ b/maps/ElmsLab.asm
@@ -570,8 +570,6 @@ CopScript:
 	turnobject ELMSLAB_OFFICER, LEFT
 	opentext
 	writetext ElmsLabOfficerText1
-	promptbutton
-	special NameRival
 	writetext ElmsLabOfficerText2
 	waitbutton
 	closetext

--- a/maps/ElmsLab.asm
+++ b/maps/ElmsLab.asm
@@ -1306,6 +1306,7 @@ ElmsLabOfficerText1:
 
 	para "Did you happen to"
 	line "get his name?"
+	prompt
 	done
 
 ElmsLabOfficerText2:


### PR DESCRIPTION
Moves rival name to the permaoptions screen, rather than setting it in Elm's lab